### PR TITLE
Add a basic installation guide

### DIFF
--- a/index.html
+++ b/index.html
@@ -343,9 +343,10 @@
         </p>
 
         <ol>
-            <li>Install the <a href="https://atom.io/packages/php-integrator-base">base package</a> and its dependencies.</li>
             <li>Install <em>PHP 7.1 or higher</em>.</li>
             <li>In <code>php.ini</code>, enable the extensions <em>mbstring, openssl</em> and <em>sqlite (the PDO variant)</em>.</li>
+            <li>In Atom editor, install the <a href="https://atom.io/packages/php-integrator-base">base package</a> and its dependencies.</li>
+            <li>If necessary, give the path to your PHP binary in <em>Settings &rarr; Packages &rarr; php-integrator-base Settings &rarr; Core</em>.</li>
             <li>Restart Atom and allow the base package to install the core.</li>
             <li>Add your project in <em>Project Manager</em> and set it up.</li>
         </ol>

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
             margin-top: 1.5em;
         }
 
-        ul li {
+        ul li, ol li {
             line-height: 1.7;
         }
 
@@ -64,7 +64,7 @@
             color: #333333;
         }
 
-        ul {
+        ul, ol {
             margin-top: 15px;
         }
 
@@ -336,6 +336,19 @@
             -legacy-php56, such as <a href="https://github.com/php-integrator/atom-base-legacy-php56">php-integrator-base-legacy-php56</a>.
             These are unmaintained, but may provide a stopgap until you are able to update.
         </p>
+
+        <h2 id="how-do-i-make-it-work">How do I make it work?</h2>
+        <p>
+            In a nutshell:
+        </p>
+
+        <ol>
+            <li>Install the <a href="https://atom.io/packages/php-integrator-base">base package</a> and its dependencies.</li>
+            <li>Install <em>PHP 7.1 or higher</em>.</li>
+            <li>In <code>php.ini</code>, enable the extensions <em>mbstring, openssl</em> and <em>sqlite (the PDO variant)</em>.</li>
+            <li>Restart Atom and allow the base package to install the core.</li>
+            <li>Add your project in <em>Project Manager</em> and set it up.</li>
+        </ol>
 
         <h2 id="what-is-it-really">Wait, now I'm confused, what is it really?</h2>
         <p>


### PR DESCRIPTION
A basic guide explaining what you need to do to get this project up and running. I found that the list of dependencies in "What do I need?" do not form a good installation guide.

In my own experience of getting the package working in Atom, I found it to be exceedingly complex and unguided. I created a detailed guide as [a post in my blog](http://thehunk.blogspot.com/2017/10/convert-atom-editor-into-php-ide-using.html) to hopefully help anyone who needs it.

That's when I realized the readme here lacks a basic guide on how to get the package working properly. Hence I am making this PR.

Screenshot _(I didn't hack your site_ 😆 _- this is done through Inspect)_:
![image](https://user-images.githubusercontent.com/6047296/32210475-c9b66558-be33-11e7-9fc0-06ddc9d715cf.png)

PS: This should probably be ported to the readme in [php-integrator/atom-base](https://github.com/php-integrator/atom-base) as well.